### PR TITLE
Integration3 MPU bringup

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,6 +346,7 @@ endforeach()
 add_subdirectory(src/firmware/${OS})
 
 add_subdirectory(src/lib/DriverFramework/framework/src)
+add_subdirectory(src/lib/DriverFramework/drivers/)
 #add_dependencies(df_driver_framework nuttx_export_${CONFIG}.stamp)
 if (NOT "${OS}" STREQUAL "nuttx")
 endif()

--- a/cmake/common/px4_base.cmake
+++ b/cmake/common/px4_base.cmake
@@ -630,6 +630,7 @@ function(px4_add_common_flags)
 		${CMAKE_BINARY_DIR}/src/modules
 		${CMAKE_SOURCE_DIR}/mavlink/include/mavlink
 		${CMAKE_SOURCE_DIR}/src/lib/DriverFramework/framework/include
+		${CMAKE_SOURCE_DIR}/src/lib/DriverFramework/drivers/imu
 		)
 
 	list(APPEND added_include_dirs

--- a/cmake/configs/posix_eagle_default.cmake
+++ b/cmake/configs/posix_eagle_default.cmake
@@ -16,6 +16,7 @@ set(config_module_list
 	systemcmds/param
 	systemcmds/mixer
 	systemcmds/ver
+	systemcmds/topic_listener
 
 	modules/mavlink
 

--- a/cmake/configs/posix_sitl_default.cmake
+++ b/cmake/configs/posix_sitl_default.cmake
@@ -18,6 +18,7 @@ set(config_module_list
 	platforms/posix/drivers/gyrosim
 	platforms/posix/drivers/rgbledsim
 	platforms/posix/drivers/ledsim
+	platforms/posix/drivers/df_imu
 	systemcmds/param
 	systemcmds/mixer
 	systemcmds/ver

--- a/cmake/configs/qurt_eagle_default.cmake
+++ b/cmake/configs/qurt_eagle_default.cmake
@@ -37,6 +37,7 @@ set(config_module_list
 #	$(EAGLE_DRIVERS_SRC)/uart_esc
 #	$(EAGLE_DRIVERS_SRC)/rc_receiver
 #	$(EAGLE_DRIVERS_SRC)/csr_gps
+	platforms/posix/drivers/df_imu
 
 	#
 	# System commands

--- a/posix-configs/eagle/flight/mainapp-flight.config
+++ b/posix-configs/eagle/flight/mainapp-flight.config
@@ -1,7 +1,2 @@
 uorb start
 muorb start
-mavlink start -u 14556
-sleep 1
-mavlink stream -u 14556 -s HIGHRES_IMU -r 50
-mavlink stream -u 14556 -s ATTITUDE -r 50
-mavlink boot_complete

--- a/posix-configs/eagle/flight/px4-flight.config
+++ b/posix-configs/eagle/flight/px4-flight.config
@@ -1,57 +1,13 @@
 uorb start
-param set CAL_GYRO0_ID 2293760
-param set CAL_ACC0_ID 1310720
-param set CAL_ACC1_ID 1376256
-param set CAL_MAG0_ID 196608
+sleep 1
+df_imu start
+sensors start
 commander start
-param set RC_RECEIVER_TYPE 1
-rc_receiver start -D /dev/tty-1
 attitude_estimator_q start
 position_estimator_inav start
 mc_pos_control start
 mc_att_control start
 sleep 1
-param set RC_MAP_THROTTLE 1
-param set RC_MAP_ROLL 2
-param set RC_MAP_PITCH 3
-param set RC_MAP_YAW 4
-param set RC_MAP_MODE_SW 5
-param set RC_MAP_POSCTL_SW 6
-param set RC1_MAX 1900
-param set RC1_MIN 1099
-param set RC1_TRIM 1099
-param set RC1_REV 1
-param set RC2_MAX 1900
-param set RC2_MIN 1099
-param set RC2_TRIM 1500
-param set RC2_REV -1
-param set RC3_MAX 1900
-param set RC3_MIN 1099
-param set RC3_TRIM 1500
-param set RC3_REV 1
-param set RC4_MAX 1900
-param set RC4_MIN 1099
-param set RC4_TRIM 1500
-param set RC4_REV -1
-param set RC5_MAX 1900
-param set RC5_MIN 1099
-param set RC5_TRIM 1500
-param set RC5_REV 1
-param set RC6_MAX 1900
-param set RC6_MIN 1099
-param set RC6_TRIM 1099
-param set RC6_REV 1
-sensors start
-param set ATT_W_MAG 0.00
-param set PE_MAG_NOISE 1.0f
-param set MPU_GYRO_LPF_ENUM 4
-param set MPU_ACC_LPF_ENUM 4
-param set MPU_SAMPLE_RATE_ENUM 2
-sleep 1
-mpu9x50 start -D /dev/spi-1
-uart_esc start -D /dev/tty-2
-csr_gps start -D /dev/tty-3
-pressure start -D /dev/i2c-2
 list_devices
 list_files
 list_tasks

--- a/src/platforms/posix/drivers/df_imu/CMakeLists.txt
+++ b/src/platforms/posix/drivers/df_imu/CMakeLists.txt
@@ -1,0 +1,42 @@
+############################################################################
+#
+#   Copyright (c) 2016 PX4 Development Team. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+# 2. Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in
+#    the documentation and/or other materials provided with the
+#    distribution.
+# 3. Neither the name PX4 nor the names of its contributors may be
+#    used to endorse or promote products derived from this software
+#    without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+# INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+# BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+# OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+# AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+# LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+# ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+############################################################################
+px4_add_module(
+	MODULE platforms__posix__drivers__df_imu
+	MAIN df_imu
+	SRCS
+		df_imu.cpp
+	DEPENDS
+		platforms__common
+		df_driver_framework
+	)
+# vim: set noet ft=cmake fenc=utf-8 ff=unix :

--- a/src/platforms/posix/drivers/df_imu/df_imu.cpp
+++ b/src/platforms/posix/drivers/df_imu/df_imu.cpp
@@ -1,0 +1,252 @@
+/****************************************************************************
+ *
+ * Copyright (c) 2016 PX4 Development Team. All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright
+ *    notice, this list of conditions and the following disclaimer in
+ *    the documentation and/or other materials provided with the
+ *    distribution.
+ * 3. Neither the name PX4 nor the names of its contributors may be
+ *    used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ * INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ * BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+ * OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED
+ * AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ * ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ *
+ ****************************************************************************/
+
+/**
+ * @file df_imu.cpp
+ * Lightweight driver to access IMU driver of DriverFramework.
+ *
+ * @author Julian Oes <julian@oes.ch>
+ */
+
+#include <px4_config.h>
+
+#include <sys/types.h>
+#include <sys/stat.h>
+#include <stdint.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <unistd.h>
+#include <px4_getopt.h>
+#include <errno.h>
+
+#include <systemlib/perf_counter.h>
+#include <systemlib/err.h>
+
+#include <drivers/drv_accel.h>
+
+#include <board_config.h>
+//#include <mathlib/math/filter/LowPassFilter2p.hpp>
+//#include <lib/conversion/rotation.h>
+//
+//#include "DriverFramework.hpp"
+#include "lib/DriverFramework/drivers/imu/mpu9250/MPU9250.hpp"
+#include "DevMgr.hpp"
+
+
+extern "C" { __EXPORT int df_imu_main(int argc, char *argv[]); }
+
+using namespace DriverFramework;
+
+
+class DfImu : MPU9250
+{
+public:
+	DfImu(/*enum Rotation rotation*/);
+	~DfImu();
+
+	//enum Rotation		_rotation;
+
+	/**
+	 * Start automatic measurement.
+	 *
+	 * @return 0 on success
+	 */
+	int		start();
+
+	/**
+	 * Stop automatic measurement.
+	 *
+	 * @return 0 on success
+	 */
+	int		stop();
+
+private:
+	virtual int _publish_callback(struct imu_sensor_data &data);
+
+};
+
+DfImu::DfImu(/*enum Rotation rotation*/) :
+	MPU9250(IMU_DEVICE_PATH)
+	/*_rotation(rotation)*/
+{
+}
+
+DfImu::~DfImu()
+{
+}
+
+int DfImu::start()
+{
+	/* start sensor */
+	PX4_WARN("DF IMU STARTED==================================================");
+	int ret = MPU9250::init();
+
+	if (ret != 0) {
+		PX4_ERR("MPU9250 init fail: %d", ret);
+		return -1;
+	}
+
+	ret = MPU9250::start();
+
+	if (ret != 0) {
+		PX4_ERR("MPU9250 start fail: %d", ret);
+		return -1;
+	}
+
+
+	return 0;
+}
+
+int DfImu::stop()
+{
+	/* stop sensor */
+	PX4_WARN("DF IMU STOPPED==================================================");
+	return 0;
+}
+
+int DfImu::_publish_callback(struct imu_sensor_data &data) {
+	PX4_WARN("publish");
+	return 0;
+};
+
+
+namespace df_imu {
+
+DfImu *g_dev = nullptr;
+
+int start(/* enum Rotation rotation */);
+int stop();
+int info();
+void usage();
+
+int start(/*enum Rotation rotation*/)
+{
+	g_dev = new DfImu(/*rotation*/);
+	return g_dev->start();
+}
+
+int stop()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	int ret = g_dev->stop();
+	if (ret != 0) {
+		PX4_ERR("driver could not be stopped");
+		return ret;
+	}
+
+	delete g_dev;
+	g_dev = nullptr;
+	return 0;
+}
+
+/**
+ * Print a little info about the driver.
+ */
+int
+info()
+{
+	if (g_dev == nullptr) {
+		PX4_ERR("driver not running");
+		return 1;
+	}
+
+	PX4_DEBUG("state @ %p", g_dev);
+
+	return 0;
+}
+
+void
+usage()
+{
+	PX4_WARN("Usage: df_imu 'start', 'info', 'stop'");
+	PX4_WARN("options:");
+	//PX4_WARN("    -R rotation");
+}
+
+} // namespace
+
+int
+df_imu_main(int argc, char *argv[])
+{
+	int ch;
+	// enum Rotation rotation = ROTATION_NONE;
+	int ret = 0;
+	int myoptind = 1;
+	const char *myoptarg = NULL;
+
+	/* jump over start/off/etc and look at options first */
+	while ((ch = px4_getopt(argc, argv, "R:", &myoptind, &myoptarg)) != EOF) {
+		switch (ch) {
+		//case 'R':
+		//	rotation = (enum Rotation)atoi(myoptarg);
+		//	break;
+
+		default:
+			df_imu::usage();
+			return 0;
+		}
+	}
+
+	if (argc <= 1) {
+		df_imu::usage();
+		return 1;
+	}
+
+	const char *verb = argv[myoptind];
+
+
+	if (!strcmp(verb, "start")) {
+		ret = df_imu::start(/*rotation*/);
+	}
+
+	else if (!strcmp(verb, "stop")) {
+		ret = df_imu::stop();
+	}
+
+	else if (!strcmp(verb, "info")) {
+		ret = df_imu::info();
+	}
+
+	else {
+		df_imu::usage();
+		return 1;
+	}
+
+	return ret;
+}


### PR DESCRIPTION
FYI: @LorenzMeier, @mcharleb 

This is my current state trying to include the MPU9250 driver from the DriverFramework into PX4.

**Steps to reproduce**

To build and upload I do:

```
git submodule update --init --recursive
make posix_eagle_default && (cd build_posix_eagle_default && make mainapp-load) && (make qurt_eagle_default && cd build_qurt_eagle_default && make libmainapp-load)
```

To get useful linker output, I recommend doing:

```
make posix
```

To upload the config files:

```
adb push posix-configs/eagle/flight/px4-flight.config /usr/share/data/adsp/px4.config
adb push posix-configs/eagle/flight/mainapp-flight.config /usr/share/data/adsp/mainapp.config
```

Open screen on 115200 and start it using:

```
(cd /home/linaro/ && ./mainapp); exit
```

To run it, type into pxh>

```
uorb start
muorb start
```

Then, open debugging on the the mini-dm:

```
$HOME/Qualcomm/Hexagon_SDK/2.0/tools/mini-dm/Linux_Debug/mini-dm
```

```
[08500/03]  48:59.670  HAP:16429:undefined  symbol _ZN15DriverFramework7MPU925016_update_callbackENS_15imu_sensor_dataE (285) /libpx  0303  symbol.c
[08500/03]  48:59.670  HAP:16429:undefined PLT symbol _ZN15DriverFramework7MPU92505startEv (980) /libpx4muorb_skel.so  0303  symbol.c
[08500/03]  48:59.670  HAP:16429:undefined PLT symbol _ZN15DriverFramework9SPIDevObjD2Ev (516) /libpx4muorb_skel.so  0303  symbol.c
```

Also the `make posix` currently fails similarly:

```
Linking CXX executable mainapp
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o): In function `DfImu::start()':
/home/julianoes/src/Firmware/src/platforms/posix/drivers/df_imu/df_imu.cpp:121: undefined reference to `DriverFramework::MPU9250::start()'
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o): In function `DriverFramework::ImuSensor::~ImuSensor()':
/home/julianoes/src/Firmware/src/lib/DriverFramework/drivers/imu/ImuSensor.hpp:76: undefined reference to `DriverFramework::SPIDevObj::~SPIDevObj()'
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o):(.rodata._ZTVN15DriverFramework9ImuSensorE[_ZTVN15DriverFramework9ImuSensorE]+0x28): undefined reference to `DriverFramework::SPIDevObj::start()'
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o):(.rodata._ZTVN15DriverFramework9ImuSensorE[_ZTVN15DriverFramework9ImuSensorE]+0x30): undefined reference to `DriverFramework::SPIDevObj::stop()'
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o):(.rodata._ZTV5DfImu[_ZTV5DfImu]+0x50): undefined reference to `DriverFramework::MPU9250::_measure()'
../../platforms/posix/drivers/df_imu/libplatforms__posix__drivers__df_imu.a(df_imu.cpp.o):(.rodata._ZTV5DfImu[_ZTV5DfImu]+0x60): undefined reference to `DriverFramework::MPU9250::_update_callback(DriverFramework::imu_sensor_data)'
collect2: error: ld returned 1 exit status
```
